### PR TITLE
Demand for low population airports

### DIFF
--- a/airline-data/src/main/scala/com/patson/DemandGenerator.scala
+++ b/airline-data/src/main/scala/com/patson/DemandGenerator.scala
@@ -130,7 +130,9 @@ object DemandGenerator {
         fromAirport.income
       }
         
-      val fromAirportAdjustedPower = fromAirportAdjustedIncome * fromAirport.population
+      val fromAirportAdjustedPower =
+	if (fromAirport.population > 50000) fromAirportAdjustedIncome * fromAirport.population
+	else fromAirportAdjustedIncome * 50000
 
       val ADJUST_FACTOR = 0.35
 

--- a/airline-data/src/main/scala/com/patson/DemandGenerator.scala
+++ b/airline-data/src/main/scala/com/patson/DemandGenerator.scala
@@ -134,10 +134,17 @@ object DemandGenerator {
 
       val ADJUST_FACTOR = 0.35
 
-      var baseDemand: Double = (fromAirportAdjustedPower.doubleValue() / 1000000 / 50000) * (toAirport.population.doubleValue() / 1000000 * toAirportIncomeLevel / 10) * (passengerType match {
+      if (toAirport.population.doubleValue() > 50000) {
+        var baseDemand: Double = (fromAirportAdjustedPower.doubleValue() / 1000000 / 50000) * (toAirport.population.doubleValue() / 1000000 * toAirportIncomeLevel / 10) * (passengerType match {
         case PassengerType.BUSINESS => 6
         case PassengerType.TOURIST | PassengerType.OLYMPICS => 1
-      }) * ADJUST_FACTOR
+        }) * ADJUST_FACTOR
+      } else {
+        var baseDemand: Double = (fromAirportAdjustedPower.doubleValue() / 1000000 / 50000) * (50000 / 1000000 * toAirportIncomeLevel / 10) * (passengerType match {
+        case PassengerType.BUSINESS => 6
+        case PassengerType.TOURIST | PassengerType.OLYMPICS => 1
+        }) * ADJUST_FACTOR
+      }
       
       if (fromAirport.countryCode != toAirport.countryCode) {
         //baseDemand = baseDemand *

--- a/airline-data/src/main/scala/com/patson/DemandGenerator.scala
+++ b/airline-data/src/main/scala/com/patson/DemandGenerator.scala
@@ -135,7 +135,7 @@ object DemandGenerator {
       val ADJUST_FACTOR = 0.35
 
       val population_adjusted = 
-	if (toAirport.population.doubleValue > 50000) toairport.population.doubleValue
+	if (toAirport.population.doubleValue > 50000) toAirport.population.doubleValue
 	else 50000
 	    
       var baseDemand: Double = (fromAirportAdjustedPower.doubleValue() / 1000000 / 50000) * (population_adjusted / 1000000 * toAirportIncomeLevel / 10) * (passengerType match {

--- a/airline-data/src/main/scala/com/patson/DemandGenerator.scala
+++ b/airline-data/src/main/scala/com/patson/DemandGenerator.scala
@@ -134,17 +134,14 @@ object DemandGenerator {
 
       val ADJUST_FACTOR = 0.35
 
-      if (toAirport.population.doubleValue() > 50000) {
-        var baseDemand: Double = (fromAirportAdjustedPower.doubleValue() / 1000000 / 50000) * (toAirport.population.doubleValue() / 1000000 * toAirportIncomeLevel / 10) * (passengerType match {
-        case PassengerType.BUSINESS => 6
-        case PassengerType.TOURIST | PassengerType.OLYMPICS => 1
-        }) * ADJUST_FACTOR
-      } else {
-        var baseDemand: Double = (fromAirportAdjustedPower.doubleValue() / 1000000 / 50000) * (50000 / 1000000 * toAirportIncomeLevel / 10) * (passengerType match {
-        case PassengerType.BUSINESS => 6
-        case PassengerType.TOURIST | PassengerType.OLYMPICS => 1
-        }) * ADJUST_FACTOR
-      }
+      val population_adjusted = 
+	if (toAirport.population.doubleValue > 50000) toairport.population.doubleValue
+	else 50000
+	    
+      var baseDemand: Double = (fromAirportAdjustedPower.doubleValue() / 1000000 / 50000) * (population_adjusted / 1000000 * toAirportIncomeLevel / 10) * (passengerType match {
+      case PassengerType.BUSINESS => 6
+      case PassengerType.TOURIST | PassengerType.OLYMPICS => 1
+      }) * ADJUST_FACTOR
       
       if (fromAirport.countryCode != toAirport.countryCode) {
         //baseDemand = baseDemand *

--- a/airline-data/src/main/scala/com/patson/data/Constants.scala
+++ b/airline-data/src/main/scala/com/patson/data/Constants.scala
@@ -74,6 +74,7 @@ object Constants {
   val AIRLINE_MODIFIER_PROPERTY_TABLE = "airline_modifier_property"
 
   
+  val AIRLINE_OPERATIONS_STRATEGY = "airline_operations_strategy"
   val INCOME_TABLE = "income"
   val CASH_FLOW_TABLE = "cash_flow"
   val AIRLINE_LOGO_TABLE = "airline_logo"
@@ -143,6 +144,7 @@ object Constants {
   val GOOGLE_RESOURCE_TABLE ="google_resource"
   val BUSY_DELEGATE_TABLE = "busy_delegate"
   val COUNTRY_DELEGATE_TASK_TABLE = "country_delegate_task"
+  val STRATEGY_DELEGATE_TASK_TABLE = "strategy_delegate_task"
   val LINK_NEGOTIATION_TASK_TABLE = "link_negotiation_delegate_task"
   val LINK_NEGOTIATION_COOL_DOWN_TABLE = "link_negotiation_cool_down"
   val LOYALIST_TABLE = "loyalist"
@@ -172,6 +174,7 @@ object Constants {
   val ALLIANCE_LABEL_COLOR_BY_ALLIANCE_TABLE = "alliance_label_color_by_alliance"
   val ALLIANCE_LABEL_COLOR_BY_AIRLINE_TABLE = "alliance_label_color_by_airline"
 
+
   //Christmas Event
   val SANTA_CLAUS_INFO_TABLE = "santa_claus_info"
   val SANTA_CLAUS_GUESS_TABLE = "santa_claus_guess"
@@ -188,8 +191,8 @@ object Constants {
   val DATABASE_CONNECTION = "jdbc:mysql://" + DB_HOST + "/" + SCHEMA_NAME +"?rewriteBatchedStatements=true&useSSL=false&autoReconnect=true&useUnicode=true&characterEncoding=utf-8" + dbParams
   // val DATABASE_CONNECTION = "jdbc:mysql://localhost:3306/airline_v2_1?socket=/tmp/mysql_3306.sock?rewriteBatchedStatements=true&useSSL=false&autoReconnect=true&useUnicode=true&characterEncoding=utf-8"
   val DB_DRIVER = "com.mysql.jdbc.Driver"
-  val DATABASE_USER = if (configFactory.hasPath("mysqldb.user")) configFactory.getString("mysqldb.user") else "mfc01"
-  val DATABASE_PASSWORD = if (configFactory.hasPath("mysqldb.password")) configFactory.getString("mysqldb.password") else "aPJdqW+5p("
+  val DATABASE_USER = if (configFactory.hasPath("mysqldb.user")) configFactory.getString("mysqldb.user") else "root"
+  val DATABASE_PASSWORD = if (configFactory.hasPath("mysqldb.password")) configFactory.getString("mysqldb.password") else ""
 
   println(s"!!!!!!!!!!!!!!!FINAL DB str $DATABASE_CONNECTION with user $DATABASE_USER")
   


### PR DESCRIPTION
At the moment, airports with low population (lower than 40,000-50,000) don't create any demand and therefore no loyalists are generated.

With this code change, for airports with population <50,000 the population for calculation is adjusted to 50,000. This creates demand from and to those airports. 

(Maybe we need a slight downsizing. Although looking at the numbers, Nakina airport had 444 aircraft movements in June 2007 (see https://www150.statcan.gc.ca/n1/en/pub/51-008-x/51-008-x2007006-eng.pdf?st=ReEsC9Z2), so even if it's mainly private aircraft, this could be realistic here.)

<img width="482" alt="image" src="https://github.com/myflyclub/airline/assets/93348049/b157477d-2085-4c5b-9ad2-3024c45fd0e3">

<img width="575" alt="image" src="https://github.com/myflyclub/airline/assets/93348049/7831bd76-d928-482c-bb97-0262b0a01625">

<img width="380" alt="image" src="https://github.com/myflyclub/airline/assets/93348049/7fd8a13f-8eb9-4753-a104-20c6c5053c49">

<img width="589" alt="image" src="https://github.com/myflyclub/airline/assets/93348049/a19b1890-fcb3-4803-ad68-4c6dc699e85e">

For low income airports, demand is still nil (or very very low):

<img width="470" alt="image" src="https://github.com/myflyclub/airline/assets/93348049/37ba1dbe-b625-4649-a94e-58eff49ea061">