### PR TITLE
feat: Add Staff to flights overview page

### DIFF
--- a/airline-web/app/controllers/LinkApplication.scala
+++ b/airline-web/app/controllers/LinkApplication.scala
@@ -173,7 +173,8 @@ class LinkApplication @Inject()(cc: ControllerComponents) extends AbstractContro
       val cancelledSeats = entry.cancelledSeats
       val satisfaction = entry.satisfaction
       val lastUpdate = entry.lastUpdate
-      Json.toJson(link).asInstanceOf[JsObject] + ("profit" -> JsNumber(profit)) + ("revenue" -> JsNumber(revenue)) + ("passengers" -> Json.toJson(passengers)) + ("capacityHistory" -> Json.toJson(capacityHistory)) + ("cancelledSeats" -> Json.toJson(cancelledSeats)) + ("satisfaction" -> JsNumber(satisfaction)) + ("lastUpdate" -> JsNumber(lastUpdate.getTimeInMillis))
+      val currentStaffRequired = entry.currentStaffRequired
+      Json.toJson(link).asInstanceOf[JsObject] + ("profit" -> JsNumber(profit)) + ("revenue" -> JsNumber(revenue)) + ("passengers" -> Json.toJson(passengers)) + ("capacityHistory" -> Json.toJson(capacityHistory)) + ("cancelledSeats" -> Json.toJson(cancelledSeats)) + ("satisfaction" -> JsNumber(satisfaction)) + ("lastUpdate" -> JsNumber(lastUpdate.getTimeInMillis)) + ("currentStaffRequired" -> JsNumber(currentStaffRequired))
     }
   }
 
@@ -563,16 +564,17 @@ class LinkApplication @Inject()(cc: ControllerComponents) extends AbstractContro
         consumptions.get(link.id).fold(0)(_.revenue),
         consumptions.get(link.id).fold(LinkClassValues.getInstance())(_.link.soldSeats),
         consumptions.get(link.id).fold(LinkClassValues.getInstance())(_.link.capacity),
-        consumptions.get(link.id).fold(LinkClassValues.getInstance())(_.link.cancelledSeats),      
+        consumptions.get(link.id).fold(LinkClassValues.getInstance())(_.link.cancelledSeats),
         consumptions.get(link.id).map(_.satisfaction).getOrElse(0),
-        lastUpdates(link.id))
+        lastUpdates(link.id),
+        link.getCurrentOfficeStaffRequired)
     }
     Ok(Json.toJson(linksWithProfit)).withHeaders(
       ACCESS_CONTROL_ALLOW_ORIGIN -> "*"
     )
   }
 
-  case class LinkExtendedInfo(link : Link, profit : Int, revenue : Int, soldSeats : LinkClassValues, capacityHistory : LinkClassValues, cancelledSeats : LinkClassValues, satisfaction : Double, lastUpdate : Calendar)
+  case class LinkExtendedInfo(link : Link, profit : Int, revenue : Int, soldSeats : LinkClassValues, capacityHistory : LinkClassValues, cancelledSeats : LinkClassValues, satisfaction : Double, lastUpdate : Calendar, currentStaffRequired : Int)
 
   def deleteLink(airlineId : Int, linkId: Int) = AuthenticatedAirline(airlineId) { request =>
     //verify the airline indeed has that link

--- a/airline-web/app/views/index.scala.html
+++ b/airline-web/app/views/index.scala.html
@@ -994,6 +994,7 @@
 											<div class="cell clickable" style="width: 4%" align="right" data-sort-property="totalLoadFactor" data-sort-order="ascending" onclick="toggleLinksTableSortOrder($(this))" title="Load Factor">LF</div>
 											<div class="cell clickable" style="width: 3%" align="right" data-sort-property="computedQuality" data-sort-order="ascending" onclick="toggleLinksTableSortOrder($(this))" title="Quality">Q</div>
 											<div class="cell clickable" style="width: 5%" align="right" data-sort-property="satisfaction" data-sort-order="ascending" onclick="toggleLinksTableSortOrder($(this))" title="Satisfaction Factor">SF</div>
+											<div class="cell clickable" style="width: 5%" align="right" data-sort-property="currentStaffRequired" data-sort-order="ascending" onclick="toggleLinksTableSortOrder($(this))" title="Current Staff Required">Staff</div>
 											<div class="cell clickable" style="width: 8%" align="right" data-sort-property="revenue" data-sort-order="ascending" onclick="toggleLinksTableSortOrder($(this))">Revenue</div>
 											<div class="cell clickable" style="width: 8%" align="right" data-sort-property="profit" data-sort-order="ascending" onclick="toggleLinksTableSortOrder($(this))">Profit</div>
 											<div class="cell clickable" style="width: 6%" align="right" data-sort-property="profitMargin" data-sort-order="ascending" onclick="toggleLinksTableSortOrder($(this))">Margin</div>
@@ -1010,6 +1011,7 @@
 											<div class="cell" style="width: 4%; border-bottom: none;"></div>
 											<div class="cell" style="width: 4%; border-bottom: none;"></div>
 											<div class="cell" style="width: 3%; border-bottom: none;"></div>
+											<div class="cell" style="width: 5%; border-bottom: none;"></div>
 											<div class="cell" style="width: 5%; border-bottom: none;"></div>
 											<div class="cell" style="width: 8%; border-bottom: none;"></div>
 											<div class="cell" style="width: 8%; border-bottom: none;"></div>

--- a/airline-web/public/javascripts/airline.js
+++ b/airline-web/public/javascripts/airline.js
@@ -1967,6 +1967,7 @@ function updateLinksTable(sortProperty, sortOrder) {
 		row.append("<div class='cell' align='right'>" + link.totalLoadFactor + '%' + "</div>")
 		row.append("<div class='cell' align='right'>" + quality + "</div>")
 		row.append("<div class='cell' align='right'>" + Math.round(link.satisfaction * 100) + '%' + "</div>")
+		row.append("<div class='cell' align='right'>" + link.currentStaffRequired + "</div>")
 		row.append("<div class='cell' align='right'>" + '$' + commaSeparateNumber(link.revenue) + "</div>")
 		row.append("<div class='cell' align='right'>" + '$' + commaSeparateNumber(link.profit) + "</div>")
 		row.append("<div class='cell' align='right'>" + link.profitMargin.toFixed(2) + "%" + "</div>")


### PR DESCRIPTION
Adds a 'Staff' column to the Flights overview page, showing the current staff requirement for each link.

![image](https://github.com/user-attachments/assets/b1acd517-970c-4ff7-a0c6-cb47ad29adea)
