### PR TITLE
Update AirlineSimulation.scala

### DIFF
--- a/airline-data/src/main/scala/com/patson/AirlineSimulation.scala
+++ b/airline-data/src/main/scala/com/patson/AirlineSimulation.scala
@@ -286,7 +286,7 @@ object AirlineSimulation {
         othersSummary.put(OtherIncomeItemType.DEPRECIATION, -1 * unassignedAirplanesDepreciation) //not a cash expense
 
         val negativeCashInterest = if (airlineValue.existingBalance < 0) {
-          (airlineValue.existingBalance * LoanInterestRateSimulation.HIGH_RATE_THRESHOLD / 52).toLong //give high interest
+          (airlineValue.existingBalance * LoanInterestRateSimulation.newRate / 52).toLong //give high interest
         } else {
           0L
         }


### PR DESCRIPTION
Forgot to change the overdraft rate to current rate ak newRat on LoanInterestRateSimulation.scala ak annualRate on Bank.scala with PR 89 and 90.

Otherwise, overdraft would be doable but way too high and never change.