### PR TITLE
[#111] Fix tooltips in modals being cut off when they overlap the modal

### DIFF
--- a/airline-web/public/stylesheets/main.css
+++ b/airline-web/public/stylesheets/main.css
@@ -1066,8 +1066,7 @@ div.future {
     max-width: 95%;
     width: 100%;
     display: block;
-    position: relative;
-    overflow-x: hidden;
+    overflow-x: visible;
 }
 
 


### PR DESCRIPTION
Closes #111 