### PR TITLE
Fix office menu sometimes not working

### DIFF
--- a/airline-web/public/javascripts/office.js
+++ b/airline-web/public/javascripts/office.js
@@ -583,12 +583,14 @@ function updateOpsDataSheet(opsData) {
             }
         });
     }
+    if (activeAirline.stats) {
 	Object.keys(activeAirline.stats).forEach((key) => {
 		const element = document.querySelector(`#opsSheet .${key}`);
 		if (element) {
 			element.textContent = commaSeparateNumber(activeAirline.stats[key]);
 		}
 	});
+    }
 }
 
 function setTargetServiceQuality(targetServiceQuality) {


### PR DESCRIPTION
when `activeAirline` is updated without `extendedInfo=true`, which is the case when `refreshPanels` is called, the resulting object does not have `stats`. In the office menu, the game would try to update with the non-existent `stats` data and error out. This stops the game from trying to update and to just move on.